### PR TITLE
Require correct postgresql extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^8.0",
         "ext-pdo": "*",
-        "ext-pgsql": "*",
+        "ext-pdo_pgsql": "*",
         "doctrine/dbal": "^3.7"
     },
     "require-dev": {


### PR DESCRIPTION
We use PDO postgres extension to connect to the database, not the postgresql one and we use no functions from the postgresql  extension.